### PR TITLE
Fix deprecated API usage

### DIFF
--- a/keymaps/change-case.cson
+++ b/keymaps/change-case.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'cmd-k cmd-c': 'change-case:camel'
   'cmd-k cmd-s': 'change-case:snake'

--- a/lib/change-case.coffee
+++ b/lib/change-case.coffee
@@ -22,7 +22,7 @@ module.exports =
       makeCommand(command)
 
 makeCommand = (command) ->
-  atom.workspaceView.command "change-case:#{command}", ->
+  atom.commands.add 'atom-workspace', "change-case:#{command}", ->
     editor = atom.workspace.getActiveEditor()
     return unless editor?
 


### PR DESCRIPTION
Address #12 as well as a second deprecation warning given under Deprecated Selectors by the deprecation cop.

The ```atom.commands.add``` was taken from https://atom.io/docs/latest/your-first-package , which uses it in the latest "your first package" tutorial.

The ```atom-workspace``` tag was given by the deprecation cop, which suggests it instead of the ```workspace``` class.