### PR TITLE
Improved selection handling

### DIFF
--- a/lib/change-case.coffee
+++ b/lib/change-case.coffee
@@ -29,12 +29,8 @@ makeCommand = (command) ->
     method = Commands[command]
     converter = ChangeCase[method]
 
-    options = {}
-    options.wordRegex = /^[\t ]*$|[^\s\/\\\(\)"':,\.;<>~!@#\$%\^&\*\|\+=\[\]\{\}`\?]+/g
-    for cursor in editor.getCursors()
-      position = cursor.getBufferPosition()
-
-      range = cursor.getCurrentWordBufferRange(options)
+    for selection in editor.getSelections()
+      range = selection.getBufferRange()
       text = editor.getTextInBufferRange(range)
       newText = converter(text)
       editor.setTextInBufferRange(range, newText)

--- a/spec/change-case-spec.coffee
+++ b/spec/change-case-spec.coffee
@@ -28,3 +28,12 @@ describe "changing case", ->
       editor.selectAll()
       atom.commands.dispatch(workspaceView, 'change-case:camel')
       expect(editor.getText()).toBe 'workspaceView'
+
+  describe "when text with more than one word is selected", ->
+    it "should camelcase selected text", ->
+      editor.setText 'the quick brown fox jumps over the lazy dog'
+      editor.moveToBottom()
+      editor.selectToTop()
+      editor.selectAll()
+      atom.commands.dispatch(workspaceView, 'change-case:camel')
+      expect(editor.getText()).toBe 'theQuickBrownFoxJumpsOverTheLazyDog'


### PR DESCRIPTION
Change case now operates on text selections instead of nearby words to the cursor.
Fixes GH-15.

This should be tested thoroughly for edge cases. Note that by not seeking words near the cursor, the selected strings are passed directly to `node-change-case` for manipulation. I'm not sure if that is in the spirit of the original use pattern for this library or not.