### PR TITLE
Improve multicursor support

### DIFF
--- a/lib/change-case.coffee
+++ b/lib/change-case.coffee
@@ -29,8 +29,14 @@ makeCommand = (command) ->
     method = Commands[command]
     converter = ChangeCase[method]
 
-    for selection in editor.getSelections()
+    editor.mutateSelectedText (selection) ->
       range = selection.getBufferRange()
-      text = editor.getTextInBufferRange(range)
+      if selection.isEmpty()
+        selection.selectWord()
+
+      text = selection.getText()
       newText = converter(text)
-      editor.setTextInBufferRange(range, newText)
+      selection.deleteSelectedText()
+      selection.insertText(newText)
+
+      selection.setBufferRange(range)

--- a/lib/change-case.coffee
+++ b/lib/change-case.coffee
@@ -30,13 +30,10 @@ makeCommand = (command) ->
     converter = ChangeCase[method]
 
     editor.mutateSelectedText (selection) ->
-      range = selection.getBufferRange()
       if selection.isEmpty()
         selection.selectWord()
 
       text = selection.getText()
       newText = converter(text)
-      selection.deleteSelectedText()
-      selection.insertText(newText)
 
-      selection.setBufferRange(range)
+      selection.insertText newText, select: true

--- a/spec/change-case-spec.coffee
+++ b/spec/change-case-spec.coffee
@@ -37,3 +37,46 @@ describe "changing case", ->
       editor.selectAll()
       atom.commands.dispatch(workspaceView, 'change-case:camel')
       expect(editor.getText()).toBe 'theQuickBrownFoxJumpsOverTheLazyDog'
+
+  describe "when text selection is empty", ->
+    it "should change case of the word nearest to the cursor", ->
+      editor.setText 'workspaceView'
+      atom.commands.dispatch(workspaceView, 'change-case:upper')
+      expect(editor.getText()).toBe 'WORKSPACEVIEW'
+
+  describe "when there are multiple selections", ->
+    it "should change case of each selection", ->
+      editor.setText '''
+      the quick brown fox
+      jumps over the lazy dog
+      '''
+      editor.selectAll()
+      editor.splitSelectionsIntoLines()
+
+      atom.commands.dispatch(workspaceView, 'change-case:camel')
+
+      expect(editor.lineTextForBufferRow(0)).toContain 'theQuickBrownFox'
+      expect(editor.lineTextForBufferRow(1)).toContain 'jumpsOverTheLazyDog'
+
+    it "should undo/redo changes in batch", ->
+      editor.setText '''
+      the quick brown fox
+      jumps over the lazy dog
+      '''
+      editor.selectAll()
+      editor.splitSelectionsIntoLines()
+
+      atom.commands.dispatch(workspaceView, 'change-case:camel')
+
+      expect(editor.lineTextForBufferRow(0)).toContain 'theQuickBrownFox'
+      expect(editor.lineTextForBufferRow(1)).toContain 'jumpsOverTheLazyDog'
+
+      editor.undo()
+
+      expect(editor.lineTextForBufferRow(0)).toContain 'the quick brown fox'
+      expect(editor.lineTextForBufferRow(1)).toContain 'jumps over the lazy dog'
+
+      editor.redo()
+
+      expect(editor.lineTextForBufferRow(0)).toContain 'theQuickBrownFox'
+      expect(editor.lineTextForBufferRow(1)).toContain 'jumpsOverTheLazyDog'

--- a/spec/change-case-spec.coffee
+++ b/spec/change-case-spec.coffee
@@ -44,6 +44,25 @@ describe "changing case", ->
       atom.commands.dispatch(workspaceView, 'change-case:upper')
       expect(editor.getText()).toBe 'WORKSPACEVIEW'
 
+    it "should select the word nearest to the cursor", ->
+      editor.setText 'workspaceView'
+      atom.commands.dispatch(workspaceView, 'change-case:upper')
+      expect(editor.getSelectedText()).toBe 'WORKSPACEVIEW'
+
+  describe "when selected text length changes after changing its case", ->
+    it "should modify selection range to fit new text", ->
+      editor.setText 'workspace.view'
+      editor.selectAll()
+
+      atom.commands.dispatch(workspaceView, 'change-case:upper')
+      expect(editor.getSelectedText()).toBe 'WORKSPACE.VIEW'
+
+      atom.commands.dispatch(workspaceView, 'change-case:camel')
+      expect(editor.getSelectedText()).toBe 'workspaceView'
+
+      atom.commands.dispatch(workspaceView, 'change-case:dot')
+      expect(editor.getSelectedText()).toBe 'workspace.view'
+
   describe "when there are multiple selections", ->
     it "should change case of each selection", ->
       editor.setText '''


### PR DESCRIPTION
Replace multiple selections in one transaction to allow batch undo/redo, which fixes #20.
Also operate on the word nearest to the cursor, when selection is empty.

Derived from [TextEditor::upperCase()](https://github.com/atom/atom/blob/v1.2.4/src/text-editor.coffee#L1012-L1017) sources.