### PR TITLE
Add menus

### DIFF
--- a/menus/change-case.cson
+++ b/menus/change-case.cson
@@ -1,0 +1,26 @@
+'menu': [
+  {
+    'label': 'Packages'
+    'submenu': [
+      'label': 'Change Case'
+      'submenu': [
+          {'label': 'lowercase',      'command': 'change-case:lower'},
+          {'label': 'lOWERCASEFIRST', 'command': 'change-case:lowerFirst'},
+          {'label': 'sentence case',  'command': 'change-case:sentence'},
+          {'label': 'Title Case',     'command': 'change-case:title'},
+          {'label': 'UPPERCASE',      'command': 'change-case:upper'},
+          {'label': 'Uppercasefirst', 'command': 'change-case:upperFirst'},
+          {'type': 'separator'},
+          {'label': 'camelCase',      'command': 'change-case:camel'},
+          {'label': 'CONSTANT_CASE',  'command': 'change-case:constant'},
+          {'label': 'dot.case',       'command': 'change-case:dot'},
+          {'label': 'param-case',     'command': 'change-case:param'},
+          {'label': 'PascalCase',     'command': 'change-case:pascal'},
+          {'label': 'path/case',      'command': 'change-case:path'},
+          {'label': 'snake_case',     'command': 'change-case:snake'},
+          {'type': 'separator'},
+          {'label': 'Swap Case',      'command': 'change-case:switch'}
+        ]
+    ]
+  }
+]


### PR DESCRIPTION
Agreed with #19 and added menu entries for commands.
However, didn't want to clutter native Atom menu, so put things under Packages/Change Case.