### PR TITLE
Add suport for mini editors

### DIFF
--- a/lib/change-case.coffee
+++ b/lib/change-case.coffee
@@ -42,4 +42,4 @@ makeCommand = (command) ->
       selection.insertText newText, select: true
 
 getEditorFromElement = (element) ->
-  element.closest('atom-text-editor')?.getModel();
+  element.closest('atom-text-editor')?.getModel()

--- a/lib/change-case.coffee
+++ b/lib/change-case.coffee
@@ -23,8 +23,10 @@ module.exports =
       makeCommand(command)
 
 makeCommand = (command) ->
-  atom.commands.add 'atom-workspace', "change-case:#{command}", ->
-    editor = atom.workspace.getActiveTextEditor()
+  atom.commands.add 'atom-workspace', "change-case:#{command}", (event) ->
+    editor = getEditorFromElement(event.target) if event?
+    editor = atom.workspace.getActiveTextEditor() unless editor?
+
     return unless editor?
 
     method = Commands[command]
@@ -38,3 +40,6 @@ makeCommand = (command) ->
       newText = converter(text)
 
       selection.insertText newText, select: true
+
+getEditorFromElement = (element) ->
+  element.closest('atom-text-editor')?.getModel();


### PR DESCRIPTION
I think changing the case of some string is a function that is not only useful in the main editors, but also in the mini editors that are used as text fields in find-and-replace or in the settings-view, however even if I configure a keybinding for this, these mini editors are ignored, because this package uses `atom.workspace.getActiveTextEditor()` to find the text editor. This PR will fix that.