### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 /spec export-ignore
 /.gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+/spec export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/.travis.yml export-ignore
+/CHANGELOG.md export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc).

Happy Hacktoberfest!